### PR TITLE
fix: allow null pole name in BusStopPoleInfo

### DIFF
--- a/src/nagoya_bus_mcp/client.py
+++ b/src/nagoya_bus_mcp/client.py
@@ -45,7 +45,7 @@ class BusStopPoleInfo(BaseModel):
 
     bc: str  # e.g., "5E1"
     c: str  # e.g., "5E1"
-    n: str  # e.g., "1番"
+    n: str | None  # e.g., "1番"
 
 
 # e.g., {"01110301": ...}


### PR DESCRIPTION
The Nagoya Bus API now returns null for the N (pole name) field on some entries in buspole_infos.json, causing a Pydantic ValidationError on server startup. Make `n` optional (str | None) to handle this.