### PR TITLE
docs: Improve README with overview, features, and examples

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,81 @@
+# nagoya-bus-mcp
+[![PyPI - Version](https://img.shields.io/pypi/v/nagoya-bus-mcp)](https://pypi.org/project/nagoya-bus-mcp/)
+[![PyPI - Python Version](https://img.shields.io/pypi/pyversions/nagoya-bus-mcp)](https://pypi.org/project/nagoya-bus-mcp/)
+[![CI](https://github.com/ymyzk/nagoya-bus-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ymyzk/nagoya-bus-mcp/actions/workflows/ci.yml)
+
+[English](README.md) | **日本語**
+
+## 概要
+Nagoya Bus MCP は、LLM から名古屋市営バスの情報を問い合わせるための [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) サーバーです。[FastMCP](https://gofastmcp.com/) を利用して構築されており、バス停の検索・時刻表の取得・バスの接近情報や位置情報の確認といったツールやプロンプトを提供します。データは名古屋市営バスの公開ウェブサイトを参照しています。
+
+Claude Desktop などの MCP クライアントに接続すると、「名古屋駅の次のバスは何時？」のように自然言語で質問するだけで、最新のデータに基づいた回答が得られます。
+
+## 機能
+このサーバーは次のツールを提供します。
+
+- **`get_station_number`** — バス停名からバス停番号を検索します（あいまい検索に対応）。
+- **`get_timetable`** — バス停のすべての系統について、曜日別の発車時刻表を取得します。
+- **`get_approach_for_route`** — 系統上のバスのリアルタイムな位置と直近の通過時刻を取得します。
+- **`get_approach_for_station`** — バス停のすべての系統について、接近中のバスのリアルタイム情報を取得します。
+
+また、よくある質問のためのプロンプトテンプレート `ask_timetable` と `ask_bus_approach` も提供します。
+
+## 質問の例
+バスのデータは日本語のため、日本語での質問が最も適しています。
+
+- 「名古屋駅のバスの時刻表を教えて」
+- 「栄のバスの接近情報を教えて」
+- 「新栄町のバス停番号を教えて」
+
+## はじめに
+Nagoya Bus MCP サーバーは PyPI で公開されています。
+
+### Claude Desktop
+`claude_desktop_config.json` に次の設定を追加します。
+```json
+{
+  "mcpServers": {
+    "nagoya-bus": {
+      "command": "uvx",
+      "args": ["nagoya-bus-mcp"]
+    }
+  }
+}
+```
+
+### Visual Studio Code
+`.vscode/mcp.json` に次の設定を追加します。
+```json
+{
+  "servers": {
+    "nagoya-bus": {
+      "type": "stdio",
+      "command": "uvx",
+      "args": ["nagoya-bus-mcp"],
+      "env": {}
+    }
+  }
+}
+```
+
+### 手動で実行する
+```shell
+# uvx を使う場合
+$ uvx nagoya-bus-mcp
+
+# Docker を使う場合
+$ docker run -i --rm ghcr.io/ymyzk/nagoya-bus-mcp
+```
+
+## 開発者向け
+```
+# MCP Inspector を使う
+$ npx @modelcontextprotocol/inspector uv run nagoya-bus-mcp
+
+# API クライアントを試す
+$ uv run python -m nagoya_bus_mcp.client
+```
+
+## データの出典
+このプロジェクトは名古屋市営バスの公開ウェブサイト (<https://www.kotsu.city.nagoya.jp>) を参照しています。
+非公式のプロジェクトであり、名古屋市が運営・公認するものではありません。

--- a/README.md
+++ b/README.md
@@ -3,6 +3,30 @@
 [![PyPI - Python Version](https://img.shields.io/pypi/pyversions/nagoya-bus-mcp)](https://pypi.org/project/nagoya-bus-mcp/)
 [![CI](https://github.com/ymyzk/nagoya-bus-mcp/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/ymyzk/nagoya-bus-mcp/actions/workflows/ci.yml)
 
+**English** | [日本語](README.ja.md)
+
+## Overview
+Nagoya Bus MCP is a [Model Context Protocol](https://modelcontextprotocol.io/) (MCP) server that lets LLMs query Nagoya City bus information. Built with [FastMCP](https://gofastmcp.com/), it exposes tools and prompts for looking up bus stops, reading timetables, and checking real-time bus approach and position information. Data is sourced from the public Nagoya City bus website.
+
+Once connected to an MCP client such as Claude Desktop, you can ask questions like "When is the next bus from Nagoya Station?" in natural language and get answers backed by live data.
+
+## Features
+The server exposes the following tools:
+
+- **`get_station_number`** — find a bus stop number from a stop name (with fuzzy matching).
+- **`get_timetable`** — departure timetables for every route at a bus stop, organized by day of week.
+- **`get_approach_for_route`** — real-time bus positions and latest passage times along a route.
+- **`get_approach_for_station`** — real-time approaching buses for all routes at a bus stop.
+
+It also provides prompt templates `ask_timetable` and `ask_bus_approach` for common questions.
+
+## Example queries
+Bus data is in Japanese, so queries work best in Japanese:
+
+- 「名古屋駅のバスの時刻表を教えて」 (What's the bus timetable at Nagoya Station?)
+- 「栄のバスの接近情報を教えて」 (Show real-time bus approach info at Sakae.)
+- 「新栄町のバス停番号を教えて」 (What's the bus stop number for Shin-sakaemachi?)
+
 ## Getting started
 The Nagoya Bus MCP server is published to PyPI.
 
@@ -51,3 +75,7 @@ $ npx @modelcontextprotocol/inspector uv run nagoya-bus-mcp
 # Try API client
 $ uv run python -m nagoya_bus_mcp.client
 ```
+
+## Data source
+This project queries the public Nagoya City bus website (<https://www.kotsu.city.nagoya.jp>).
+It is an unofficial project and is not affiliated with or endorsed by the City of Nagoya.


### PR DESCRIPTION
## Summary
- Add an **Overview** explaining what the project is (an MCP server, built with FastMCP, for querying Nagoya City bus timetables and real-time approach info).
- Add a **Features** list documenting the 4 tools (`get_station_number`, `get_timetable`, `get_approach_for_route`, `get_approach_for_station`) and the 2 prompt templates.
- Add **Example queries** (Japanese natural-language prompts) and a **Data source** note.
- Add a Japanese translation `README.ja.md`, cross-linked with the English README via a language-switch line.
- Existing install (Claude Desktop / VS Code / uvx / Docker) and developer sections are unchanged.

## Test plan
- [ ] Tool/prompt names in the README match those registered in `src/nagoya_bus_mcp/mcp/server.py`.
- [ ] Example queries match the templates in `src/nagoya_bus_mcp/mcp/prompts.py`.
- [ ] EN ↔ JA cross-links resolve and Markdown renders correctly on GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)