### PR TITLE
Tame Dependabot: group updates monthly, drop automerge

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,72 @@ updates:
   - package-ecosystem: "pre-commit"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
   - package-ecosystem: "uv"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    cooldown:
+      default-days: 7
+    groups:
+      monthly-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      monthly-major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,25 +143,3 @@ jobs:
           subject-name: ghcr.io/ymyzk/nagoya-bus-mcp
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: true
-
-  dependabot:
-    runs-on: ubuntu-latest
-    needs:
-      - build
-    permissions:
-      contents: write
-      pull-requests: write
-    if: github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    name: Automatically merge Dependabot PRs
-    steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-      - name: Merge Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
-        run: gh pr merge --merge "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Cuts Dependabot PR volume at the source so every dependency update can realistically be reviewed by hand, rather than relying on automerge to absorb the flood.

Based on GitHub's [Tame Dependabot: group your updates, slow the cadence, keep security fast](https://github.blog/security/supply-chain-security/tame-dependabot-group-your-updates-slow-the-cadence-keep-security-fast/).

## `.github/dependabot.yml`

| | Before | After |
|---|---|---|
| Cadence | weekly | monthly |
| Grouping | none (one PR per dependency) | minor/patch batched, major batched separately |
| Cooldown | built-in default | 7 days |
| Ecosystems | `pre-commit`, `github-actions`, `uv` | + `docker` |

`docker` is new — the root `Dockerfile`'s base image was previously never updated by Dependabot.

**Security updates are unaffected.** The groups deliberately omit `applies-to`, which defaults them to `version-updates` only. Security-advisory PRs stay individual and immediate — batching them into the monthly PR would delay exactly the fixes that shouldn't wait.

Expected volume is up to 8 grouped PRs/month at the ceiling, and realistically fewer, since a group with no eligible updates produces no PR at all.

## `.github/workflows/ci.yml`

Removes the `dependabot` job that auto-merged minor/patch PRs via `dependabot/fetch-metadata` + `gh pr merge`. Grouped monthly PRs are reviewable by hand, so it's no longer earning its keep.

This also drops that job's `contents: write` and `pull-requests: write` grants, a real reduction in what a compromised action in this workflow could do. Every remaining job declares its own `permissions` block and there is no top-level `permissions:` key, so nothing else needs adjusting.

## Follow-ups outside these files

- Repository-level auto-merge (Settings → General → "Allow auto-merge") and any branch-protection automerge rules live server-side and are untouched by this PR — worth disabling if you want automerge fully gone.
- GitHub validates `dependabot.yml` server-side only after merge. Insights → Dependency graph → Dependabot will show a config-error banner if anything is wrong, and "Check for updates" there forces a grouped run instead of waiting for the monthly schedule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)