### PR TITLE
chore: Ignore ruff CPY (flake8-copyright) rules

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,7 +84,7 @@ target-version = "py311"
 
 [tool.ruff.lint]
 select = ["ALL"]
-ignore = ["COM812", "FIX002", "PLC2401", "T201", "TD"]
+ignore = ["COM812", "CPY", "FIX002", "PLC2401", "T201", "TD"]
 
 [tool.ruff.lint.isort]
 force-sort-within-sections = true


### PR DESCRIPTION
ruff 0.16.0 promoted `CPY001` (`missing-copyright-notice`) out of preview. Because this project uses `select = ["ALL"]`, the newly stable rule is picked up automatically and fails on every Python file — 21 errors, with no autofix available. This is what blocks CI on #253 (`ruff-pre-commit` v0.15.22 → 0.16.2).

Licensing here is covered by the top-level MIT `LICENSE` plus the `license`/`license-files` metadata in `pyproject.toml`, and no source file carries a copyright header today, so this opts out of the rule rather than adding per-file boilerplate.

Ignoring the `CPY` prefix (rather than just `CPY001`) matches the existing `TD` entry and avoids a repeat if further flake8-copyright rules stabilize later.

Once this lands, #253 needs a `@dependabot rebase` to re-run against the fixed config.

Verified with `git ls-files '*.py' | xargs uvx ruff@0.16.2 check`, `uv run pre-commit run --all-files`, and `uv run pytest` (51 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)